### PR TITLE
Add minimal Obsidian plugin setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# BlurOb Plugin
+
+This repository contains a minimal Obsidian plugin example.
+
+## Building
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Build the plugin
+   ```bash
+   npm run build
+   ```
+
+The compiled files will be placed in the `dist` directory and `manifest.json` points to `dist/main.js` as the plugin entry point.

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const obsidian_1 = require("obsidian");
+class BlurOb extends obsidian_1.Plugin {
+    async onload() {
+        console.log('BlurOb plugin loaded');
+    }
+    onunload() {
+        console.log('BlurOb plugin unloaded');
+    }
+}
+exports.default = BlurOb;

--- a/main.js
+++ b/main.js
@@ -1,2 +1,0 @@
-console.log("Hello from BlurOb!");
-

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+  "id": "blur-ob",
+  "name": "BlurOb",
+  "version": "0.0.1",
+  "main": "dist/main.js"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "blurob",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "blurob",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "blurob",
+  "version": "0.0.1",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,11 @@
+import { Plugin } from 'obsidian';
+
+export default class BlurOb extends Plugin {
+  async onload() {
+    console.log('BlurOb plugin loaded');
+  }
+
+  onunload() {
+    console.log('BlurOb plugin unloaded');
+  }
+}

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -1,0 +1,6 @@
+declare module 'obsidian' {
+  export class Plugin {
+    app: any;
+    manifest: any;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up TypeScript build with `npm run build`
- implement basic plugin in `src/main.ts`
- add manifest.json for Obsidian
- document build steps in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68697016cd8c832ab428d83563f61aae