### PR TITLE
Add customizable settings tab

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,12 +1,146 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 const obsidian_1 = require("obsidian");
+const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
+const DEFAULT_SETTINGS = {
+    videoPath: '',
+    opacity: [],
+    blurLeft: 0,
+    blurCenter: 0,
+    blurRight: 0,
+};
 class BlurOb extends obsidian_1.Plugin {
+    constructor() {
+        super(...arguments);
+        this.settings = DEFAULT_SETTINGS;
+        this.wallpapersDir = '';
+    }
     async onload() {
         console.log('BlurOb plugin loaded');
+        await this.loadSettings();
+        // Determine plugin wallpapers directory
+        const baseDir = this.app.vault.configDir || '';
+        this.wallpapersDir = path.join(baseDir, 'plugins', this.manifest.id, 'wallpapers');
+        fs.mkdirSync(this.wallpapersDir, { recursive: true });
+        this.addSettingTab(new BlurObSettingTab(this.app, this));
     }
     onunload() {
         console.log('BlurOb plugin unloaded');
     }
+    async loadSettings() {
+        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    }
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
 }
 exports.default = BlurOb;
+class BlurObSettingTab extends obsidian_1.PluginSettingTab {
+    constructor(app, plugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
+    display() {
+        const { containerEl } = this;
+        const el = containerEl;
+        el.empty();
+        el.createEl('h2', { text: 'BlurOb Settings' });
+        // --- Upload video wallpaper ---
+        el.createEl('h3', { text: 'Upload video wallpaper' });
+        const fileInput = el.createEl('input', { type: 'file', attr: { accept: 'video/*' } });
+        const current = el.createEl('div');
+        current.textContent = this.plugin.settings.videoPath || 'No video selected';
+        fileInput.onchange = async () => {
+            var _a;
+            const file = (_a = fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
+            if (file) {
+                const arrayBuffer = await file.arrayBuffer();
+                const dest = path.join(this.plugin.wallpapersDir, file.name);
+                fs.writeFileSync(dest, Buffer.from(arrayBuffer));
+                this.plugin.settings.videoPath = dest;
+                current.textContent = dest;
+                await this.plugin.saveSettings();
+            }
+        };
+        // --- Opacity table ---
+        el.createEl('h3', { text: 'Opacity table' });
+        const table = el.createDiv();
+        const renderTable = () => {
+            table.empty();
+            this.plugin.settings.opacity.forEach((row, index) => {
+                const rowDiv = table.createDiv({ cls: 'opacity-row' });
+                const text = rowDiv.createEl('input', { type: 'text', value: row.selector });
+                text.onchange = () => {
+                    row.selector = text.value;
+                    this.plugin.saveSettings();
+                };
+                const slider = rowDiv.createEl('input', { type: 'range', attr: { min: '0', max: '1', step: '0.05', value: String(row.value) } });
+                slider.oninput = () => {
+                    row.value = parseFloat(slider.value);
+                    this.plugin.saveSettings();
+                };
+                const removeBtn = rowDiv.createEl('button', { text: 'Remove' });
+                removeBtn.onclick = () => {
+                    this.plugin.settings.opacity.splice(index, 1);
+                    renderTable();
+                    this.plugin.saveSettings();
+                };
+            });
+        };
+        const addBtn = el.createEl('button', { text: 'Add' });
+        addBtn.onclick = () => {
+            this.plugin.settings.opacity.push({ selector: '', value: 1 });
+            renderTable();
+            this.plugin.saveSettings();
+        };
+        renderTable();
+        // --- Blur zones ---
+        el.createEl('h3', { text: 'Blur zones' });
+        const makeSlider = (label, key) => {
+            const wrap = el.createDiv();
+            wrap.createEl('label', { text: label });
+            const slider = wrap.createEl('input', { type: 'range', attr: { min: '0', max: '100', value: String(this.plugin.settings[key]) } });
+            slider.oninput = () => {
+                this.plugin.settings[key] = parseInt(slider.value);
+                this.plugin.saveSettings();
+            };
+        };
+        makeSlider('Left', 'blurLeft');
+        makeSlider('Center', 'blurCenter');
+        makeSlider('Right', 'blurRight');
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,18 @@
       "name": "blurob",
       "version": "0.0.1",
       "devDependencies": {
+        "@types/node": "^20.11.17",
         "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
+      "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/typescript": {
@@ -24,6 +35,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@types/node": "^20.11.17"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,134 @@
-import { Plugin } from 'obsidian';
+import { Plugin, PluginSettingTab } from 'obsidian';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface BlurObSettings {
+  videoPath: string;
+  opacity: { selector: string; value: number }[];
+  blurLeft: number;
+  blurCenter: number;
+  blurRight: number;
+}
+
+const DEFAULT_SETTINGS: BlurObSettings = {
+  videoPath: '',
+  opacity: [],
+  blurLeft: 0,
+  blurCenter: 0,
+  blurRight: 0,
+};
 
 export default class BlurOb extends Plugin {
+  settings: BlurObSettings = DEFAULT_SETTINGS;
+  wallpapersDir: string = '';
+
   async onload() {
     console.log('BlurOb plugin loaded');
+    await this.loadSettings();
+
+    // Determine plugin wallpapers directory
+    const baseDir = (this.app as any).vault.configDir || '';
+    this.wallpapersDir = path.join(baseDir, 'plugins', this.manifest.id, 'wallpapers');
+    fs.mkdirSync(this.wallpapersDir, { recursive: true });
+
+    this.addSettingTab(new BlurObSettingTab(this.app, this));
   }
 
   onunload() {
     console.log('BlurOb plugin unloaded');
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
+}
+
+class BlurObSettingTab extends PluginSettingTab {
+  plugin: BlurOb;
+
+  constructor(app: any, plugin: BlurOb) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    const el = containerEl as any;
+    el.empty();
+    el.createEl('h2', { text: 'BlurOb Settings' });
+
+    // --- Upload video wallpaper ---
+    el.createEl('h3', { text: 'Upload video wallpaper' });
+    const fileInput = el.createEl('input', { type: 'file', attr: { accept: 'video/*' } });
+    const current = el.createEl('div');
+    current.textContent = this.plugin.settings.videoPath || 'No video selected';
+    fileInput.onchange = async () => {
+      const file = (fileInput as HTMLInputElement).files?.[0];
+      if (file) {
+        const arrayBuffer = await file.arrayBuffer();
+        const dest = path.join(this.plugin.wallpapersDir, file.name);
+        fs.writeFileSync(dest, Buffer.from(arrayBuffer));
+        this.plugin.settings.videoPath = dest;
+        current.textContent = dest;
+        await this.plugin.saveSettings();
+      }
+    };
+
+    // --- Opacity table ---
+    el.createEl('h3', { text: 'Opacity table' });
+    const table = el.createDiv();
+
+    const renderTable = () => {
+      table.empty();
+      this.plugin.settings.opacity.forEach((row, index) => {
+        const rowDiv = (table as any).createDiv({ cls: 'opacity-row' });
+        const text = rowDiv.createEl('input', { type: 'text', value: row.selector });
+        text.onchange = () => {
+          row.selector = text.value;
+          this.plugin.saveSettings();
+        };
+        const slider = rowDiv.createEl('input', { type: 'range', attr: { min: '0', max: '1', step: '0.05', value: String(row.value) } });
+        slider.oninput = () => {
+          row.value = parseFloat((slider as HTMLInputElement).value);
+          this.plugin.saveSettings();
+        };
+        const removeBtn = rowDiv.createEl('button', { text: 'Remove' });
+        removeBtn.onclick = () => {
+          this.plugin.settings.opacity.splice(index, 1);
+          renderTable();
+          this.plugin.saveSettings();
+        };
+      });
+    };
+
+    const addBtn = el.createEl('button', { text: 'Add' });
+    addBtn.onclick = () => {
+      this.plugin.settings.opacity.push({ selector: '', value: 1 });
+      renderTable();
+      this.plugin.saveSettings();
+    };
+
+    renderTable();
+
+    // --- Blur zones ---
+    el.createEl('h3', { text: 'Blur zones' });
+
+    const makeSlider = (label: string, key: 'blurLeft' | 'blurCenter' | 'blurRight') => {
+      const wrap = el.createDiv();
+      wrap.createEl('label', { text: label });
+      const slider = wrap.createEl('input', { type: 'range', attr: { min: '0', max: '100', value: String(this.plugin.settings[key]) } });
+      slider.oninput = () => {
+        this.plugin.settings[key] = parseInt((slider as HTMLInputElement).value);
+        this.plugin.saveSettings();
+      };
+    };
+
+    makeSlider('Left', 'blurLeft');
+    makeSlider('Center', 'blurCenter');
+    makeSlider('Right', 'blurRight');
   }
 }

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -2,5 +2,16 @@ declare module 'obsidian' {
   export class Plugin {
     app: any;
     manifest: any;
+    addSettingTab(tab: PluginSettingTab): void;
+    loadData(): Promise<any>;
+    saveData(data: any): Promise<void>;
+  }
+
+  export class PluginSettingTab {
+    app: any;
+    plugin: Plugin;
+    containerEl: HTMLElement;
+    constructor(app: any, plugin: Plugin);
+    display(): void;
   }
 }


### PR DESCRIPTION
## Summary
- provide typings for PluginSettingTab and basic methods
- add new settings tab for video, opacity and blur zones
- include @types/node for build

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68697b3d2f00832ab807d0d17f398479